### PR TITLE
print args

### DIFF
--- a/src/main/java/com/vimandi/PlayWithGit/PlayWithGitApplication.java
+++ b/src/main/java/com/vimandi/PlayWithGit/PlayWithGitApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class PlayWithGitApplication {
 
 	public static void main(String[] args) {
+		System.out.println(args);
 		SpringApplication.run(PlayWithGitApplication.class, args);
 	}
 


### PR DESCRIPTION
Issue : not able to see args on console

RCA: because not printing in java class

Fix provided: added sys out to print args

![after_fix_utc1](https://github.com/user-attachments/assets/de9f6f9d-7593-48cc-8f06-862b59ad27ef)
